### PR TITLE
Fixed a critical bug in VALD dictionary

### DIFF
--- a/nodes/vald/node_atom/dictionaries.py
+++ b/nodes/vald/node_atom/dictionaries.py
@@ -45,7 +45,7 @@ RETURNABLES = {\
 'RadTransWavelength':'RadTran.waves()',
 'RadTransWavelengthUnit':u'A',
 'RadTransWavelengthMethod':'RadTran.method_return',
-'RadTransWavelengthComment': ['Vacuum wavelength from state energies (Ritz)','Wavelength (non-Ritz), measured in air and converted to vacuum'],
+'RadTransWavelengthComment': 'RadTran.wavecomment()',
 'RadTransProcess':"RadTran.transition_type",
 'RadTransWavelengthRef':'RadTran.waverefs()',
 'RadTransUpperStateRef':'RadTran.upstate_id',

--- a/nodes/vald/node_atom/models.py
+++ b/nodes/vald/node_atom/models.py
@@ -106,6 +106,11 @@ class Transition(Model):
         if self.waveair: return self.wavevac, self.waveair
         else: return self.wavevac
 
+    WAVE_COMMENT = ['Vacuum wavelength from state energies (Ritz)','Wavelength (non-Ritz), measured in air and converted to vacuum']
+    def wavecomment(self):
+        if self.waveair: return self.WAVE_COMMENT
+        else: return self.WAVE_COMMENT[0]
+
     def waverefs(self):
         if self.waveair: return self.wavevac_ref, self.waveair_ref
         else: return self.wavevac_ref

--- a/vamdctap/generators.py
+++ b/vamdctap/generators.py
@@ -337,7 +337,6 @@ def makeDataType(tagname, keyword, G, extraAttr={}, extraElem={}):
         return ''
     if isiterable(value):
         return makeRepeatedDataType(tagname, keyword, G)
-
     unit = G(keyword + 'Unit')
     method = G(keyword + 'Method')
     comment = G(keyword + 'Comment')


### PR DESCRIPTION
It tried to supply a list of WavelengthComments also when the database only contains the wavecac wavelength. This caused the system to switch to MakeDataType instead of MakeRepeatedDataType, where lists are not supported, causing the generator to die horribly. With this applied the dev-portal output should work as it should again.
.
Griatch
