### PR TITLE
Added new field to VALD

### DIFF
--- a/nodes/vald/fullimport.sh
+++ b/nodes/vald/fullimport.sh
@@ -4,7 +4,7 @@
 # but mainly a reminder of the steps involved.
 
 AorM="atom"
-VDB="vald_$AroM"
+VDB="vald_atom_alt"
 VUSR="vald"
 VPWD="V@ld"
 

--- a/nodes/vald/mapping_vald3.py
+++ b/nodes/vald/mapping_vald3.py
@@ -183,13 +183,15 @@ def species_component(species_file, outfile):
     f.close()
     print "... Created file %s." % outfile
 
-# mapper for caching the connections between upper/lower state IDS and
-# their respective unique pk values. This depends on a MySQL database
-# vald_import exists. We create four database connections to be able
-# to handle multi-processing for each individual point where the
-# linefunc unique_state_id() is accessed.
-# OBS - detta kan återanvändas så länge inte in-dumpen ändrats;
-# import MySQLdb
+## mapper for caching the connections between upper/lower state IDS and
+## their respective unique pk values. This depends on a MySQL database
+## vald_import exists. We create four database connections to be able
+## to handle multi-processing for each individual point where the
+## linefunc unique_state_id() is accessed.
+## OBS - this is less efficient than the dictionary version below.
+
+# import MySQLd
+#
 # CURSORS = [MySQLdb.connect(host="localhost", user="vald", passwd="V@ld", db="vald_import").cursor() for i in range(4)]
 # #CURSORS[0].execute("DROP TABLE IF EXISTS mapping;")
 # #CURSORS[0].execute("CREATE TABLE mapping (idnum INT PRIMARY KEY AUTO_INCREMENT UNIQUE NOT NULL, charid VARCHAR(255) UNIQUE NOT NULL, INDEX(charid, idnum));") #ENGINE=MEMORY);
@@ -232,9 +234,11 @@ def species_component(species_file, outfile):
 #     #print cursorid, charid, idnum
 #     return idnum
 
-# Alternative import mechanism using a dictionary - the state table is
-# pretty small and can thus fit in memory; Using the MySQL-based
-# mapper above is very slow (4157 mins = 2.8 days) for a rewrite)
+# Alternative import mechanism to the mysql-based on above. This one
+# uses a dictionary - the state table is pretty small and can thus fit in
+# memory; Using the MySQL-based mapper above takes 4157 mins (2 days 21 hours)
+# for a rewrite. Using this solution takes 3442 mins (2 days 9 hours) on the same data.
+
 from multiprocessing import Manager, Lock
 from ctypes import c_int
 MANAGER = Manager()
@@ -335,11 +339,8 @@ mapping = [
             {'cname':'lande',
              'cbyte':(charrange, 84,90),
              'cnull':'99.00'},
-            #{'cname':'coupling',
-            # 'cbyte':(charrange, 124,126)},
-            #{'cname':'term',
-            # 'cbyte':(charrange, 126,212)},
-
+            {'cname':'term_desc',
+             'cbyte':(charrange, 126,212)},
             # read from 2nd open vald file (2nd line per record)
             {'filenum':1,
              'cname':'energy_ref',
@@ -350,15 +351,6 @@ mapping = [
             {'filenum':1,
              'cname':'level_ref',
              'cbyte':(charrange, 65,73)},
-
-            ## this links to linelists rather than refs directly
-            #{'cname':'energy_linelist',
-            # 'cbyte':(charrange, 342,346)},
-            #{'cname':'lande_linelist',
-            # 'cbyte':(charrange, 350,354)},
-            #{'cname':'level_linelist',
-            # 'cbyte':(charrange, 366,370)},
-
             # these are read from 1st open term file
             {'filenum':2, # use term file
              'cname':'j',
@@ -422,15 +414,8 @@ mapping = [
             {'cname':'lande',
              'cbyte':(charrange, 90,96),
              'cnull':'99.00'},
-
-            #{'cname':'j',
-            # 'cbyte':(charrange, 78,84)},
-
-            #{'cname':'coupling',
-            # 'cbyte':(charrange, 212,214)},
-            #{'cname':'term',
-            # 'cbyte':(charrange, 214,300)},
-
+            {'cname':'term_desc',
+             'cbyte':(charrange, 214,300)},
             # read from 2nd open vald file (2nd line per record)
             {'filenum':1,
              'cname':'energy_ref',

--- a/nodes/vald/node_atom/dictionaries.py
+++ b/nodes/vald/node_atom/dictionaries.py
@@ -15,6 +15,7 @@ RETURNABLES = {\
 'AtomNuclearCharge':'Atom.atomic',
 'AtomIonCharge':'Atom.ion',
 'AtomMassNumber':'Atom.massno',
+'AtomStateDescription': 'AtomState.term_desc',
 'AtomStateLandeFactor':'AtomState.lande',
 'AtomStateLandeFactorUnit':'unitless',
 'AtomStateLandeFactorRef':'AtomState.lande_ref_id',

--- a/nodes/vald/node_atom/models.py
+++ b/nodes/vald/node_atom/models.py
@@ -8,18 +8,12 @@ class State(Model):
 
     energy = DecimalField(max_digits=15, decimal_places=4,null=True, db_index=True)
     lande = DecimalField(max_digits=6, decimal_places=2,null=True)
-    #coupling = CharField(max_length=2, null=True)
-    #term = CharField(max_length=56, null=True)
+    term_desc = CharField(max_length=86, null=True)
 
     energy_ref = ForeignKey(Reference, related_name='isenergyref_state', db_index=False)
     lande_ref = ForeignKey(Reference, related_name='islanderef_state', db_index=False)
     level_ref = ForeignKey(Reference, related_name='islevelref_state', db_index=False)
 
-    #energy_linelist = ForeignKey(LineList, related_name='isenergylinelist_state', db_index=False)
-    #lande_linelist = ForeignKey(LineList, related_name='islandelinelist_state', db_index=False)
-    #level_linelist = ForeignKey(LineList, related_name='islevellinelist_state', db_index=False)
-
-    #coupling = CharField(max_length=4, null=True)
     j = DecimalField(max_digits=3, decimal_places=1,db_column=u'J', null=True)
     l = PositiveSmallIntegerField(db_column=u'L', null=True)
     s = DecimalField(max_digits=3, decimal_places=1,db_column=u'S', null=True)
@@ -57,8 +51,6 @@ class Transition(Model):
 
     wavevac = DecimalField(max_digits=16, decimal_places=8, db_index=True)
     waveair = DecimalField(max_digits=16, decimal_places=8, null=True, db_index=False)
-    # wavevac (calculated from energies, has separated wavewac_ref (same as energies))
-    # waveair + waveair_ref
 
     species = ForeignKey(Species, db_index=True)
     loggf = DecimalField(max_digits=8, decimal_places=3, null=True)
@@ -74,11 +66,8 @@ class Transition(Model):
     accur = DecimalField(max_digits=6, decimal_places=3, null=True)
     #comment = CharField(max_length=128, null=True)
 
-    #srctag = ForeignKey(Reference, db_index=False)
-
     wavevac_ref = ForeignKey(Reference, related_name='iswavevacref_trans', db_index=False)
     waveair_ref = ForeignKey(Reference, related_name='iswaveairref_trans', db_index=False)
-    # change above to waveair_ref?
     loggf_ref = ForeignKey(Reference, related_name='isloggfref_trans', db_index=False)
     gammarad_ref = ForeignKey(Reference, related_name='isgammaradref_trans', db_index=False)
     gammastark_ref = ForeignKey(Reference, related_name='isgammastarkref_trans', db_index=False)

--- a/nodes/vald/settings_atom.py
+++ b/nodes/vald/settings_atom.py
@@ -12,7 +12,7 @@ INSTALLED_APPS.append(NODEPKG)
 DATABASES = {
   'default': {
     'ENGINE': 'django.db.backends.mysql',
-    'NAME': 'vald_atom',
+    'NAME': 'vald_atom_alt',
     'USER': 'vald',
     'PASSWORD': 'V@ld',
   },


### PR DESCRIPTION
Updated the VALD State model with a term_desc field and added it to the dictionary as AtomStateDescription (which I assume is what the portal uses for its "description" header when looking at the details in "Single State View"). 
The matching database is imported already and sits in vald_atom_alt. 
.
Griatch
